### PR TITLE
added optional window to avoid requiring 'jsdom' everytime

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@
 * Trevor Jim <trever@research.att.com>
 * Alasdair Mercer <mercer.alasdair@gmail.com>
 * Tim Chaplin <tjchaplin@hotmail.com>
+* Aziz Khoury <bentael@gmail.com>

--- a/src/md.coffee
+++ b/src/md.coffee
@@ -15,6 +15,8 @@ DEFAULT_OPTIONS   =
   base:     if window? then window.document.baseURI else "file://#{process.cwd()}"
   debug:    no
   inline:   no
+# require jsdom if there is no window object
+JS_DOM = unless window? then require('jsdom') else null
 # Save the previous value of the global `md` variable for *noConflict* mode.
 PREVIOUS_MD       = @md
 # Map of replacement strings for *special* Markdown characters.
@@ -144,8 +146,7 @@ class HtmlParser
     # Use the `window` option when specified or create a DOM if `window` doesn't exist (i.e. when running in node).
     @win = @options.window or (window ? null)
     unless @win?
-      jsdom = jsdom or require('jsdom')
-      doc  = jsdom.jsdom null, null,
+      doc  = JS_DOM.jsdom null, null,
         features: FetchExternalResources: no
         url:      @options.base
       @win = doc.createWindow()

--- a/src/md.coffee
+++ b/src/md.coffee
@@ -141,11 +141,11 @@ class HtmlParser
     for own key, defaultValue of DEFAULT_OPTIONS
       @options[key] = defaultValue if typeof @options[key] is 'undefined'
 
-    # Use the options.window if one is passed, issue #42
-    # If not, create a DOM if `window` doesn't exist (i.e. when running in node).
-    @win = @options.window or if window? then window else null
+    # Use the `window` option when specified or create a DOM if `window` doesn't exist (i.e. when running in node).
+    @win = @options.window or (window ? null)
     unless @win?
-      doc  = require('jsdom').jsdom null, null,
+      jsdom = jsdom or require('jsdom')
+      doc  = jsdom.jsdom null, null,
         features: FetchExternalResources: no
         url:      @options.base
       @win = doc.createWindow()

--- a/src/md.coffee
+++ b/src/md.coffee
@@ -141,8 +141,9 @@ class HtmlParser
     for own key, defaultValue of DEFAULT_OPTIONS
       @options[key] = defaultValue if typeof @options[key] is 'undefined'
 
-    # Create a DOM if `window` doesn't exist (i.e. when running in node).
-    @win = window ? null
+    # Use the options.window if one is passed, issue #42
+    # If not, create a DOM if `window` doesn't exist (i.e. when running in node).
+    @win = @options.window or if window? then window else null
     unless @win?
       doc  = require('jsdom').jsdom null, null,
         features: FetchExternalResources: no


### PR DESCRIPTION
I added an optional `options.window` so I can now `require('jsdom')` and `createWindow()` before hand

kinda like that.

``` javascript
var posts = [ .... ]; // a large array of html content posts
var md = require('html-md');
var doc = require('jsdom').jsdom(null, null, {
          features: {
            FetchExternalResources: false
          },
          url: window ? window.document.baseURI : "file://" + (process.cwd()) 
        });
var win = doc.createWindow();

for (var i = 0; i < posts.length; i++) {
   posts[i].content = md(posts[i].content), {window: win});
}
```

I built and successfully tested locally, but didn't commit build files per your [contribution guide](https://github.com/neocotic/html.md/blob/master/CONTRIBUTING.md#making-changes)
Thanks, great module btw. 

closes [issue#42](https://github.com/neocotic/html.md/issues/42)
